### PR TITLE
Fix bag when there are more than 4 items in table

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -6,7 +6,7 @@ plugins {
 }
 
 group = "com.github.t45k"
-version = "0.1.1"
+version = "0.1.2"
 
 repositories {
     mavenCentral()

--- a/src/main/kotlin/com/github/t45k/kotlin_data_table/tableToRow.kt
+++ b/src/main/kotlin/com/github/t45k/kotlin_data_table/tableToRow.kt
@@ -20,8 +20,9 @@ class TableToRowDSL {
 }
 
 class TableRow(internal val values: MutableList<Any>) {
-    infix fun `|`(other: Any) {
+    infix fun `|`(other: Any): TableRow {
         values += other
+        return this
     }
 
     operator fun <T> component1(): T = values[0] as T

--- a/src/test/kotlin/com/github/t45k/kotlin_data_table/TableTest.kt
+++ b/src/test/kotlin/com/github/t45k/kotlin_data_table/TableTest.kt
@@ -5,20 +5,20 @@ import kotlin.test.assertEquals
 
 class TableTest {
     private val expected = listOf(
-        Person("Bob", 27, Gender.MALE),
-        Person("Alice", 34, Gender.FEMALE),
-        Person("Alex", 1, Gender.MALE),
+        Person("Bob", 27, Gender.MALE, "foo"),
+        Person("Alice", 34, Gender.FEMALE, "bar"),
+        Person("Alex", 1, Gender.MALE, "baz"),
     )
 
     @Test
     fun tableToRowTest() {
         val actual = tableToRow {
             // @formatter:off
-            "Bob"   `|` 27 `|` Gender.MALE
-            "Alice" `|` 34 `|` Gender.FEMALE
-            "Alex"  `|`  1 `|` Gender.MALE
+            "Bob"   `|` 27 `|` Gender.MALE   `|` "foo"
+            "Alice" `|` 34 `|` Gender.FEMALE `|` "bar"
+            "Alex"  `|`  1 `|` Gender.MALE   `|` "baz"
             // @formatter:on
-        }.map { (name: String, age: Int, gender: Gender) -> Person(name, age, gender) }
+        }.map { (name: String, age: Int, gender: Gender, remark: String) -> Person(name, age, gender, remark) }
 
         assertEquals(expected, actual)
     }
@@ -27,12 +27,12 @@ class TableTest {
     fun tableToRowWithNameTest() {
         val actual = tableToRowWithName {
             // @formatter:off
-            "name"  `|` "age" `|` "gender"
-            "Bob"   `|`    27 `|` Gender.MALE
-            "Alice" `|`    34 `|` Gender.FEMALE
-            "Alex"  `|`     1 `|` Gender.MALE
+            "name"  `|` "age" `|` "gender"       `|` "remark"
+            "Bob"   `|`    27 `|` Gender.MALE    `|` "foo"
+            "Alice" `|`    34 `|` Gender.FEMALE  `|` "bar"
+            "Alex"  `|`     1 `|` Gender.MALE    `|` "baz"
             // @formatter:on
-        }.map { Person(it["name"], it["age"], it["gender"]) }
+        }.map { Person(it["name"], it["age"], it["gender"], it["remark"]) }
 
         assertEquals(expected, actual)
     }
@@ -41,11 +41,11 @@ class TableTest {
     fun strTableToRow() {
         val actual = strTableToRow(
             """
-                Bob   |  27 | MALE
-                Alice |  34 | FEMALE
-                Alex  |   1 | MALE
+                Bob   |  27 | MALE   | foo
+                Alice |  34 | FEMALE | bar
+                Alex  |   1 | MALE   | baz
             """.trimIndent()
-        ).map { (name, age, gender) -> Person(name, age.toInt(), Gender.valueOf(gender)) }
+        ).map { (name, age, gender, remark) -> Person(name, age.toInt(), Gender.valueOf(gender), remark) }
 
         assertEquals(expected, actual)
     }
@@ -54,13 +54,13 @@ class TableTest {
     fun `strTableToRow ignores empty line`() {
         val actual = strTableToRow(
             """
-                Bob   |  27 | MALE
+                Bob   |  27 | MALE   | foo
                 
-                Alice |  34 | FEMALE
+                Alice |  34 | FEMALE | bar
                 
-                Alex  |   1 | MALE
+                Alex  |   1 | MALE   | baz
             """
-        ).map { (name, age, gender) -> Person(name, age.toInt(), Gender.valueOf(gender)) }
+        ).map { (name, age, gender, remark) -> Person(name, age.toInt(), Gender.valueOf(gender), remark) }
 
         assertEquals(expected, actual)
     }
@@ -69,12 +69,12 @@ class TableTest {
     fun strTableToRowWithName() {
         val actual = strTableToRowWithName(
             """
-                name  | age | gender
-                Bob   |  27 | MALE
-                Alice |  34 | FEMALE
-                Alex  |   1 | MALE
+                name  | age | gender | remark
+                Bob   |  27 | MALE   | foo
+                Alice |  34 | FEMALE | bar
+                Alex  |   1 | MALE   | baz
             """.trimIndent()
-        ).map { Person(it["name"], it["age"].toInt(), Gender.valueOf(it["gender"])) }
+        ).map { Person(it["name"], it["age"].toInt(), Gender.valueOf(it["gender"]), it["remark"]) }
 
         assertEquals(expected, actual)
     }
@@ -83,22 +83,22 @@ class TableTest {
     fun `strTableToRowWithName ignores empty line`() {
         val actual = strTableToRowWithName(
             """
-                name  | age | gender
+                name  | age | gender | remark
                 
-                Bob   |  27 | MALE
+                Bob   |  27 | MALE   | foo
                 
-                Alice |  34 | FEMALE
+                Alice |  34 | FEMALE | bar
                 
-                Alex  |   1 | MALE
+                Alex  |   1 | MALE   | baz
             """
         ).map {
-            Person(it["name"], it["age"].toInt(), Gender.valueOf(it["gender"]))
+            Person(it["name"], it["age"].toInt(), Gender.valueOf(it["gender"]), it["remark"])
         }
 
         assertEquals(expected, actual)
     }
 
-    private data class Person(val name: String, val age: Int, val gender: Gender)
+    private data class Person(val name: String, val age: Int, val gender: Gender, val remark: String)
 
     private enum class Gender {
         MALE, FEMALE;


### PR DESCRIPTION
since `|` instance function returns unit, it doesn't used when there are more than 4 items.
now, the function returns this